### PR TITLE
splitting cablecast_project_shows out into a template, adding pager

### DIFF
--- a/cablecast.module
+++ b/cablecast.module
@@ -450,7 +450,13 @@ function cablecast_load($node) {
     case "cablecast_project":
       $result = db_fetch_object(db_query('SELECT cablecast_project_id, cablecast_project_has_podcast, cablecast_project_podcast_name, cablecast_project_podcast_description, cablecast_project_podcast_url FROM {cablecast_project} WHERE vid=%d', $node->vid));
 	  $cablecast_shows = array();
-	  $show_nids = db_query("SELECT nid FROM {cablecast_show} WHERE project_id =  $result->cablecast_project_id ORDER BY event_date DESC");
+//	  $show_nids = db_query("SELECT nid FROM {cablecast_show} WHERE project_id =  $result->cablecast_project_id ORDER BY event_date DESC");
+      $limit = variable_get('cablecast_project_shows_per_page',NULL);
+      if(!$limit) {
+          $limit = 20;
+          variable_set('cablecast_project_shows_per_page',20);
+      }
+      $show_nids = pager_query("SELECT nid FROM {cablecast_show} WHERE project_id = %d ORDER BY event_date DESC",$limit,0,NULL, array($result->cablecast_project_id));
 	  while($r = db_fetch_array($show_nids))  {
             $show_node = node_load($r['nid']);
 			$show = new stdClass();
@@ -540,6 +546,7 @@ function cablecast_theme() {
     ),
   		  'cablecast_project_shows'  => array(
   			'arguments'  =>  array('node'),
+        'template' => 'cablecast_project_shows',
     ),
           'cablecast_schedule_page' => array(
               'arguments' =>  array('schedule_nodes' => NULL, 'schedule_date' => NULL, 'channel_name' => NULL),
@@ -586,17 +593,6 @@ function theme_cablecast_show_streaming_file_url($node) {
     $output = "";
   }
   return $output;
-}
-
-function theme_cablecast_project_shows($node)  {
-	$output = "<div class=\"cablecast-project-shows\">\n".
-			  "<table class=\"cablecast-project-shows-list\">\n".
-			  "<tr><th>Show Title</th><th>Show Description</th><th>Link</th></tr>\n";
-	foreach($node->cablecast_shows as $show)  {
-		$output = $output."<tr><td>".check_markup($show->title)."</td><td>".check_markup($show->body)."</td><td>".l('View More', 'node/'.$show->nid)."</td></tr>\n";
-	}
-	$output = $output."</table></div>\n";
-	return $output;
 }
 
 function cablecast_views_api() {

--- a/cablecast_project_shows.tpl.php
+++ b/cablecast_project_shows.tpl.php
@@ -1,0 +1,11 @@
+<?php
+$node = $variables[0];
+$output = "<div class=\"cablecast-project-shows\">\n".
+			  "<table class=\"cablecast-project-shows-list\">\n".
+			  "<tr><th>Show Title</th><th>Show Description</th><th>Link</th></tr>\n";
+	foreach($node->cablecast_shows as $show)  {
+		$output = $output."<tr><td>".check_markup($show->title)."</td><td>".check_markup($show->body)."</td><td>".l('View More', 'node/'.$show->nid)."</td></tr>\n";
+	}
+	$output = $output."</table>". theme('pager',array(), variable_get('cablecast_project_shows_per_page',20)). " </div>\n";
+	print $output;
+


### PR DESCRIPTION
Hi Ray, I've been having to modify the cablecast_load function to use pager_query for the shows that get loaded as part of a cablecast_project (we have some projects with well over 100 shows). I also think it makes sense to move the theming into a template. Would you consider incorporating these changes - after proper vetting of course? A new template file, and some changes to cablecast.module. 

I wasn't quite able to figure out how to pass $node into the template, so the template is using $variables[0] instead. If you can straighten that out, I'd appreciate it. Also, I have it using get_variable for the pager_query limit, if none found, it sets it at 20. This should probably be exposed in settings(?). Or some other way?

This is my first time trying out forking followed by a pull request. Let me know if I'm not using it appropriately!
