### PR TITLE
On cablecast.install:

### DIFF
--- a/cablecast/cablecast.install
+++ b/cablecast/cablecast.install
@@ -497,7 +497,7 @@ function _cablecast_installed_schedule_item_instances() {
   return array(
     'cablecast_schedule_item_id' => array(
       'field_name' => 'cablecast_schedule_item_id',
-      'label' => 'Scheudle Item ID',
+      'label' => 'Schedule Item ID',
       'widget' => array(
         'type' => 'number',
       ),
@@ -512,7 +512,7 @@ function _cablecast_installed_schedule_item_instances() {
     ),
     'cablecast_schedule_end_time' => array(
       'field_name' => 'cablecast_schedule_end_time',
-      'label' => $t('Start Time'),
+      'label' => $t('End Time'),
       'type' => 'date',
       'widget' => array(
         'type' => 'date_text',

--- a/cablecast/cablecast.module
+++ b/cablecast/cablecast.module
@@ -12,7 +12,7 @@ function cablecast_node_info() {
       'locked' => TRUE,
     ),
     'cablecast_project' => array(
-      'name' => t('Cablecasst Project'),
+      'name' => t('Cablecast Project'),
       'base' => 'node_content',
       'description' => t('Represents a Cablecast Project.'),
       'has_title' => TRUE,


### PR DESCRIPTION
Corrected spelling on label from Scheudle Item ID to Schedule Item ID. Changed cablecast_schedule_end_time label from Start Time to End Time.

On cablecast.module:
Corrected spelling from Cablecasst Project to Cablecast Project.
